### PR TITLE
Bump to v21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM yandex/clickhouse-server:20
+FROM yandex/clickhouse-server:21


### PR DESCRIPTION
The latest release of ClickHouse includes some useful functionality (notably [UDFs](https://clickhouse.com/learn/lessons/whatsnew-clickhouse-21.10/)) -- and it might make sense to default to the newest version, particularly with the spin out and [funding](https://clickhouse.com/blog/en/2021/clickhouse-raises-250m-series-b/).